### PR TITLE
Add Github CI definition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+# Adapted from https://github.com/actions/starter-workflows/blob/main/ci/rust.yml
+name: CI
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ] 
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose


### PR DESCRIPTION
We want to make sure that this repository follows good code practices. We add a continuous integration (CI) job on pushes and PRs. This will ensure that our code always builds.