### PR TITLE
Fix the branch in the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,9 @@ name: CI
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ $default-branch ] 
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Turns out that the example from the GitHub workflows repository needs the actual branch name.